### PR TITLE
auth module, and entity

### DIFF
--- a/backend/stark-cert-backend/package-lock.json
+++ b/backend/stark-cert-backend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.0",
-        "@nestjs/config": "^4.0.2",
+        "@nestjs/config": "^4.0.1",
         "@nestjs/core": "^11.0.0",
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/mapped-types": "*",

--- a/backend/stark-cert-backend/src/app.module.ts
+++ b/backend/stark-cert-backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { Auth } from './auth/entities/auth.entity';
 
 @Module({
   imports: [

--- a/backend/stark-cert-backend/src/auth/auth.module.ts
+++ b/backend/stark-cert-backend/src/auth/auth.module.ts
@@ -5,10 +5,12 @@ import { JwtModule } from '@nestjs/jwt';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt-strategy';
 import { LocalStrategy } from './strategies/local-strategy';
+import { Auth } from './entities/auth.entity';
 
 @Module({
   imports: [
     PassportModule,
+    Auth,
     JwtModule.register({
       secret: process.env.JWT_SECRET || 'defaultSecret',
       signOptions: { expiresIn: '1h' },

--- a/backend/stark-cert-backend/src/auth/entities/auth.entity.ts
+++ b/backend/stark-cert-backend/src/auth/entities/auth.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity()
+export class Auth {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column()
+  password: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
### 🔐 Setup Basic Authentication Module and Entity

#### **Description**

This PR sets up the foundational structure for authentication in the system by creating the `AuthModule` and defining the `Auth` entity. This entity is connected to the ORM and prepared for future use in authentication workflows such as login and registration.

---

#### **Changes Made**

* Created `AuthModule` at `/src/auth/auth.module.ts`
* Defined `Auth` entity with the following fields:

  * `id`: UUID (Primary Key)
  * `email`: string (Unique)
  * `password`: string
  * `createdAt`, `updatedAt`: timestamp columns
* Integrated the `Auth` entity with TypeORM using `@Entity()`
* Registered `AuthModule` in `AppModule` (if applicable)

---

#### **Acceptance Criteria**

* ✅ `AuthModule` is created and registered
* ✅ `AuthEntity` is defined with required fields
* ✅ Entity is connected to TypeORM and ready for use
* ❌ No DTOs, services, or controllers included (per task scope)

---

#### **Path**

* `/src/auth/`
* `/src/auth/auth.module.ts`
* `/src/auth/entities/auth.entity.ts`

closes #1 
