### PR TITLE
feat: add CertificateStatus enum for lifecycle state management

### DIFF
--- a/backend/stark-cert-backend/src/modules/certificates/dto/create-certificate.dto.ts
+++ b/backend/stark-cert-backend/src/modules/certificates/dto/create-certificate.dto.ts
@@ -1,6 +1,8 @@
 import { IsString, IsUUID, IsEmail, IsOptional, IsDateString, IsObject, IsEnum, IsArray, IsUrl, MinLength, MaxLength } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { CertificateType } from '../enums/certificate-type.enum';
+import { CertificateStatus } from '../enums/certificate-status.enum';
+
 
 export class CreateCertificateDto {
   @ApiProperty({ example: 'Web Development Certificate', description: 'Certificate title' })
@@ -78,6 +80,15 @@ export class CreateCertificateDto {
   @IsArray()
   @IsString({ each: true })
   assetUrls?: string[];
+
+   @ApiPropertyOptional({
+    example: CertificateStatus.PENDING,
+    enum: CertificateStatus,
+    description: 'Lifecycle status of the certificate',
+  })
+  @IsOptional()
+  @IsEnum(CertificateStatus)
+  status?: CertificateStatus;
 
   @ApiPropertyOptional({ description: 'Blockchain-specific metadata' })
   @IsOptional()


### PR DESCRIPTION
### 🔥 Summary

This PR implements the `CertificateStatus` enum to define the lifecycle states of a certificate.

### ✅ Enum Values
- `ACTIVE`
- `EXPIRED`
- `REVOKED`
- `PENDING`

### 📂 File Location
- `src/modules/certificates/enums/certificate-status.enum.ts`

### ♻️ Usage
To be used across entities, DTOs, and service layers for validation, filtering, and display logic.

### 🧪 Tested
- Verified enum compiles without errors.
- Ready for integration in certificate-related modules.

### 🧹 Closes
- close #21
